### PR TITLE
fix truncation issue and page number not appearing on first page

### DIFF
--- a/easier_ps/easier_ps.cls
+++ b/easier_ps/easier_ps.cls
@@ -41,7 +41,7 @@
 \newcommand*{\GetUniContentPath}{\@UniContentPath}
 
 % LAYOUT SETTINGS
-\geometry{a4paper, includehead, left=1.0in, right=1.0in, top=0.4in, bottom=0.4in} % Page margins, change as you need
+\geometry{a4paper, includehead, includefoot, left=1.0in, right=1.0in, top=0.4in, bottom=0.4in} % Include header/footer in layout
 \setlength{\parskip}{0.2em}     % Space between paragraphs
 \linespread{1.06}               % Line spacing
 
@@ -51,19 +51,20 @@
 \fancyhead[L]{\@StudentName}    % Custom left header: Student Name
 \fancyhead[R]{\@UniversityName} % Custom right header: University Name
 \fancyfoot[C]{\thepage}         % Add a page number in the footer
-\setlength{\headheight}{32pt}   % Adjust the height of the header
-\setlength{\headsep}{24pt}      % Space between the header and content
+\setlength{\headheight}{42pt}   % Adjust the height of the header
+\setlength{\headsep}{16pt}      % Space between the header and content
+\setlength{\footskip}{18pt}     % Ensure footer is separated from text
 
 % HEADER EXPANSION FOR FIRST PAGE
 \fancypagestyle{firstpageheader}{
     \fancyhf{} % Clear header and footer for first page
-    \fancyhead[C]{
-        \centering {\LARGE \textsc{Personal Statement}} \\ [1.0em] % Larger font for the title
-        \makebox[\textwidth][r]{\@UniversityName} \\ % University Name on the right
-        \makebox[\textwidth][l]{\@StudentName \hfill \@ProgramName} % Student Name and Program Name aligned
-        \vspace{-14pt} % Adjust vertical space between elements
+    \fancyhead[C]{%
+        \parbox[b][\headheight][b]{\textwidth}{%
+            \centering
+            {\LARGE \textsc{Personal Statement}}\\[0.35em]% Title line
+            \makebox[\textwidth][r]{\@UniversityName}\\% University Name on the right
+            \makebox[\textwidth][l]{\@StudentName \hfill \@ProgramName}% Student and Program aligned
+        }%
     }
     \fancyfoot[C]{\thepage}       % Add a page number in the footer
-    \setlength{\headheight}{80pt} % Increased height for the first page header
-    \setlength{\headsep}{16pt}    % Increase space between the header and content
 }

--- a/easier_sop/easier_sop.cls
+++ b/easier_sop/easier_sop.cls
@@ -44,7 +44,7 @@
 \newcommand*{\GetUniContentPath}{\@UniContentPath}
 
 % LAYOUT SETTINGS
-\geometry{a4paper, includehead, left=0.6in, right=0.6in, top=0.4in, bottom=0.6in} % Page margins, change as you need
+\geometry{a4paper, includehead, includefoot, left=0.6in, right=0.6in, top=0.4in, bottom=0.6in} % Include header/footer in layout
 \setlength{\parskip}{0.2em}     % Space between paragraphs
 \linespread{1.06}               % Line spacing
 
@@ -54,21 +54,22 @@
 \fancyhead[L]{\@StudentName}    % Custom left header: Student Name
 \fancyhead[R]{\@UniversityName} % Custom right header: University Name
 \fancyfoot[C]{\thepage}         % Add a page number in the footer
-\setlength{\headheight}{20pt}   % Adjust the height of the header
+\setlength{\headheight}{62pt}   % Adjust the height of the header
 \setlength{\headsep}{16pt}      % Space between the header and content
+\setlength{\footskip}{18pt}     % Ensure footer is separated from text
 
 % HEADER EXPANSION FOR FIRST PAGE
 \fancypagestyle{firstpageheader}{
     \fancyhf{} % Clear header and footer for first page
-    \fancyhead[C]{
-        \centering {\LARGE \textsc{Statement of Purpose}} \\ [0.35em] % Larger font for the title
-        \makebox[\textwidth][r]{\@UniversityName} \\ % University Name on the right
-        \makebox[\textwidth][l]{\@StudentName \hfill \@ProgramName} % Student Name and Program Name aligned
-        \vspace{-14pt} % Adjust vertical space between elements
+    \fancyhead[C]{%
+        \parbox[b][\headheight][b]{\textwidth}{%
+            \centering
+            {\LARGE \textsc{Statement of Purpose}}\\[0.35em]% Title line
+            \makebox[\textwidth][r]{\@UniversityName}\\% University Name on the right
+            \makebox[\textwidth][l]{\@StudentName \hfill \@ProgramName}% Student and Program aligned
+        }%
     }
     \fancyfoot[C]{\thepage}       % Add a page number in the footer
-    \setlength{\headheight}{60pt} % Increased height for the first page header
-    \setlength{\headsep}{16pt}    % Increase space between the header and content
 }
 
 % CITATION SETTINGS


### PR DESCRIPTION
This PR fixes the following issues:
- First page didn’t truncate when content exceeded one page.
- Page number in the footer was missing on the first page.

These were the problems:
- the geometry layout did not include the footer, so the page number of the first page could be pushed out of the text block.
- the header lengths (ie `\headheight`, `\headsep`) are customized only for the first page style, so the page layout wasn’t recalculated to account for the taller header.